### PR TITLE
Disable pipeline settings when sync build

### DIFF
--- a/frontend/src/pages/dashboard/components/DashboardTopPanel.tsx
+++ b/frontend/src/pages/dashboard/components/DashboardTopPanel.tsx
@@ -208,7 +208,7 @@ export const DashboardTopPanel: FC<DashboardTopPanelProps> = ({
 				</div>
 				<div>
 					<div css={pipelineSettingStyles}>
-						<PipelineSetting projectId={projectId} syncBuild={syncBuilds} />
+						<PipelineSetting projectId={projectId} syncBuild={syncBuilds} syncing={syncing}/>
 					</div>
 					<Button type="primary" icon={<SyncOutlined />} loading={syncing} onClick={syncBuilds}>
 						{syncing ? "Synchronizing" : "Sync Data"}

--- a/frontend/src/pages/dashboard/components/PipelineSetting.tsx
+++ b/frontend/src/pages/dashboard/components/PipelineSetting.tsx
@@ -33,9 +33,10 @@ export enum PipelineSettingStatus {
 	UPDATE,
 }
 
-const PipelineSetting: FC<{ projectId: string; syncBuild: () => void }> = ({
+const PipelineSetting: FC<{ projectId: string; syncBuild: () => void; syncing: boolean }> = ({
 	projectId,
 	syncBuild,
+	syncing
 }) => {
 	const { visible, handleToggleVisible } = useModalVisible();
 	const {
@@ -78,7 +79,7 @@ const PipelineSetting: FC<{ projectId: string; syncBuild: () => void }> = ({
 
 	return (
 		<>
-			<Button css={settingStyles} onClick={handleToggleVisible} type={"link"}>
+			<Button css={settingStyles} onClick={handleToggleVisible} type={"link"} disabled={syncing}>
 				<SettingOutlined />
 				Pipeline Settings
 			</Button>


### PR DESCRIPTION
fixes #10 
This change will disable the **Pipeline Settings** button during synchronisation .

![image](https://user-images.githubusercontent.com/5915092/114078471-9b37bd00-98c6-11eb-8487-1ecabe4322a9.png)
