### PR TITLE
fix: mismatch of parameter and value

### DIFF
--- a/backend/src/main/kotlin/metrik/project/infrastructure/github/feign/GithubFeignClient.kt
+++ b/backend/src/main/kotlin/metrik/project/infrastructure/github/feign/GithubFeignClient.kt
@@ -43,7 +43,7 @@ interface GithubFeignClient {
         @PathVariable("repo") repo: String,
         @RequestParam("since", required = false) since: String? = null,
         @RequestParam("until", required = false) until: String? = null,
-        @RequestParam("sha", required = false) branch: String? = null,
+        @RequestParam("branch", required = false) branch: String? = null,
         @RequestParam("per_page", required = false) perPage: Int? = null,
         @RequestParam("page", required = false) pageIndex: Int? = null,
     ): List<CommitResponse>?


### PR DESCRIPTION
this fixes an exception which appears when a branch name is passed
into the api request to the sha query parameter. Fixed to be
consistent witch parameters and values to branch, usage of sha
would only get a single commit.