### PR TITLE
Feature: Auto sync button

### DIFF
--- a/frontend/src/pages/dashboard/components/DashboardTopPanel.tsx
+++ b/frontend/src/pages/dashboard/components/DashboardTopPanel.tsx
@@ -115,6 +115,7 @@ const INPUT_FIELD_LABELS = {
 
 const AUTO_SYNC_OPTIONS: AutoSyncOption[] = [
 	{ period: null, text: "off" },
+	{ period: 1, text: "1s" },
 	{ period: 5, text: "5s" },
 	{ period: 10, text: "10s" },
 	{ period: 30, text: "30s" },
@@ -133,6 +134,7 @@ export const DashboardTopPanel: FC<DashboardTopPanelProps> = ({
 }) => {
 	const [isFullscreenVisible, setIsFullscreenVisible] = useState(false);
 	const [autoSyncPeriod, setAutoSyncPeriod] = useState<AutoSyncOption>(AUTO_SYNC_OPTIONS[0]);
+	const [autoSyncJob, setAutoSyncJob] = useState<NodeJS.Timeout | null>(null);
 	useEffect(() => {
 		const btn = document.getElementById("sync");
 		setInterval(() => {
@@ -144,6 +146,18 @@ export const DashboardTopPanel: FC<DashboardTopPanelProps> = ({
 			}
 		}, 1800000);
 	}, []);
+	useEffect(() => {
+		if (autoSyncJob) {
+			clearInterval(autoSyncJob);
+		}
+		if (autoSyncPeriod.period) {
+			setAutoSyncJob(
+				setInterval(() => {
+					syncBuildsWithProgress();
+				}, autoSyncPeriod.period * 1000)
+			);
+		}
+	}, [autoSyncPeriod]);
 	const defaultValues = {
 		duration: [
 			moment(new Date(), dateFormatYYYYMMDD).startOf("day"),

--- a/frontend/src/pages/dashboard/components/DashboardTopPanel.tsx
+++ b/frontend/src/pages/dashboard/components/DashboardTopPanel.tsx
@@ -62,6 +62,7 @@ const pipelineSettingStyles = css({
 });
 
 const autoSyncOverlayStyles = css({
+	boxShadow: "2px 2px 3px black",
 	padding: "10px",
 	backgroundColor: "white",
 	"&:hover": { backgroundColor: "grey" },
@@ -311,13 +312,17 @@ export const DashboardTopPanel: FC<DashboardTopPanelProps> = ({
 						<Button
 							id="sync"
 							type="primary"
+							style={{ borderRadius: "2px 0px 0px 2px" }}
 							icon={<SyncOutlined />}
 							loading={syncInProgress}
 							onClick={syncBuildsWithProgress}>
 							{syncInProgress ? "Synchronizing" : "Sync Data"}
 						</Button>
 						<Dropdown trigger={["click"]} overlay={autoSyncOverlay()}>
-							<Button type="primary" onClick={e => e.preventDefault()}>
+							<Button
+								type="primary"
+								onClick={e => e.preventDefault()}
+								style={{ borderRadius: "0px 2px 2px 0px" }}>
 								{autoSyncPeriod.period && autoSyncPeriod.text}
 								<DownOutlined />
 							</Button>


### PR DESCRIPTION
Hi,

I added a auto sync button which will automatically trigger the sync function of sync button with time period selected by user.
Which is similar to Grafana's page.
![image](https://user-images.githubusercontent.com/10886456/208339112-96f0e124-6674-40e6-8003-b932e0204c02.png)


Also, I tried to use [Dropdown.Button](https://4x.ant.design/components/dropdown/#Usage-upgrade-after-4.24.0) which is provided by AntD. But get some problems.
Generally, currently we are using 4.10.2 but AntD v4 already 4.24.0. And unfortunately the Dropdown.Button is not working well on 4.10.2.
The issue is: in 4.10.2, I looks the Dropdown.Button not support "loading", so the loading icon and loading style need to customize a lot.
At the same time, if I upgrade the AntD, then the page style will be messed up.
In this case, I will not try to upgrade it for this feature and will use an independent dropdown component for this feature.