### PR TITLE
should use ISO time when calling Github api.

### DIFF
--- a/backend/src/main/kotlin/metrik/project/domain/service/githubactions/CommitService.kt
+++ b/backend/src/main/kotlin/metrik/project/domain/service/githubactions/CommitService.kt
@@ -8,6 +8,7 @@ import metrik.project.infrastructure.github.feign.GithubFeignClient
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.net.URL
+import java.time.ZonedDateTime
 
 @Service
 class CommitService(
@@ -17,10 +18,10 @@ class CommitService(
     private val defaultMaxPerPage = 100
 
     fun getCommitsBetweenTimePeriod(
-        startTimeStamp: Long,
-        endTimeStamp: Long,
-        branch: String? = null,
-        pipeline: PipelineConfiguration
+            startTimeStamp: ZonedDateTime?,
+            endTimeStamp: ZonedDateTime,
+            branch: String? = null,
+            pipeline: PipelineConfiguration
     ): List<Commit> {
         logger.info("Started sync for Github Actions commits [${pipeline.url}]/[$branch]")
 
@@ -50,15 +51,15 @@ class CommitService(
     private fun retrieveCommits(
         credential: String,
         url: String,
-        startTimeStamp: Long,
-        endTimeStamp: Long,
+        startTimeStamp: ZonedDateTime?,
+        endTimeStamp: ZonedDateTime,
         branch: String? = null,
         pageIndex: Int? = null
     ): List<GithubCommit> {
         logger.info(
             "Get Github Commits - " +
                 "Sending request to Github Feign Client with owner: $url, " +
-                "since: ${startTimeStamp.toLocalDateTime()}, until: ${endTimeStamp.toLocalDateTime()}, " +
+                "since: ${startTimeStamp?.toLocalDateTime() ?: 0L.toLocalDateTime()}, until: ${endTimeStamp.toLocalDateTime()}, " +
                 "branch: $branch, pageIndex: $pageIndex"
         )
         val commits = with(githubFeignClient) {
@@ -67,7 +68,7 @@ class CommitService(
                     credential,
                     owner,
                     repo,
-                    if (startTimeStamp == 0L) null else startTimeStamp.toString(),
+                    startTimeStamp?.toString(),
                     endTimeStamp.toString(),
                     branch,
                     defaultMaxPerPage,

--- a/backend/src/main/kotlin/metrik/project/domain/service/githubactions/CommitService.kt
+++ b/backend/src/main/kotlin/metrik/project/domain/service/githubactions/CommitService.kt
@@ -18,10 +18,10 @@ class CommitService(
     private val defaultMaxPerPage = 100
 
     fun getCommitsBetweenTimePeriod(
-            startTimeStamp: ZonedDateTime?,
-            endTimeStamp: ZonedDateTime,
-            branch: String? = null,
-            pipeline: PipelineConfiguration
+        startTimeStamp: ZonedDateTime?,
+        endTimeStamp: ZonedDateTime,
+        branch: String? = null,
+        pipeline: PipelineConfiguration
     ): List<Commit> {
         logger.info("Started sync for Github Actions commits [${pipeline.url}]/[$branch]")
 
@@ -59,7 +59,8 @@ class CommitService(
         logger.info(
             "Get Github Commits - " +
                 "Sending request to Github Feign Client with owner: $url, " +
-                "since: ${startTimeStamp?.toLocalDateTime() ?: 0L.toLocalDateTime()}, until: ${endTimeStamp.toLocalDateTime()}, " +
+                "since: ${startTimeStamp?.toLocalDateTime() ?: 0L.toLocalDateTime()}, " +
+                "until: ${endTimeStamp.toLocalDateTime()}, " +
                 "branch: $branch, pageIndex: $pageIndex"
         )
         val commits = with(githubFeignClient) {

--- a/backend/src/main/kotlin/metrik/project/domain/service/githubactions/PipelineCommitService.kt
+++ b/backend/src/main/kotlin/metrik/project/domain/service/githubactions/PipelineCommitService.kt
@@ -94,7 +94,7 @@ class PipelineCommitService(
             ZonedDateTime.ofInstant(Instant.ofEpochMilli(it), ZoneOffset.UTC)
         }
         val allCommits = commitService.getCommitsBetweenTimePeriod(
-                previousRunZonedDateTime?.plus(COMMIT_OFFSET, ChronoUnit.SECONDS),
+            previousRunZonedDateTime?.plus(COMMIT_OFFSET, ChronoUnit.SECONDS),
             latestTimestampInRuns,
             branch = lastRun.branch,
             pipeline = pipeline,

--- a/backend/src/main/kotlin/metrik/project/domain/service/githubactions/PipelineCommitService.kt
+++ b/backend/src/main/kotlin/metrik/project/domain/service/githubactions/PipelineCommitService.kt
@@ -94,9 +94,8 @@ class PipelineCommitService(
             ZonedDateTime.ofInstant(Instant.ofEpochMilli(it), ZoneOffset.UTC)
         }
         val allCommits = commitService.getCommitsBetweenTimePeriod(
-            previousRunZonedDateTime?.plus(COMMIT_OFFSET, ChronoUnit.SECONDS)
-                ?.toTimestamp() ?: 0,
-            latestTimestampInRuns.toTimestamp(),
+                previousRunZonedDateTime?.plus(COMMIT_OFFSET, ChronoUnit.SECONDS),
+            latestTimestampInRuns,
             branch = lastRun.branch,
             pipeline = pipeline,
         )

--- a/backend/src/test/kotlin/metrik/project/domain/service/githubactions/CommitServiceTest.kt
+++ b/backend/src/test/kotlin/metrik/project/domain/service/githubactions/CommitServiceTest.kt
@@ -4,7 +4,6 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
-import metrik.infrastructure.utlils.toTimestamp
 import metrik.project.TestFixture.githubActionsPipeline
 import metrik.project.infrastructure.github.feign.GithubFeignClient
 import metrik.project.infrastructure.github.feign.response.CommitResponse
@@ -12,6 +11,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.ZonedDateTime
+import java.util.*
 
 @ExtendWith(MockKExtension::class)
 internal class CommitServiceTest {
@@ -41,7 +41,7 @@ internal class CommitServiceTest {
         )
 
         val commitsBetweenTimePeriod =
-            commitService.getCommitsBetweenTimePeriod(0, endTimeStamp, null, githubActionsPipeline)
+            commitService.getCommitsBetweenTimePeriod(null, endTimeStamp, null, githubActionsPipeline)
 
         assertThat(commitsBetweenTimePeriod.size).isEqualTo(1)
         assertThat(commitsBetweenTimePeriod[0].pipelineId).isEqualTo(githubActionsPipeline.id)
@@ -55,7 +55,7 @@ internal class CommitServiceTest {
                 credential = any(),
                 owner = any(),
                 repo = any(),
-                since = any(),
+                since = startTimeStamp.toString(),
                 until = endTimeStamp.toString(),
                 branch = "master",
                 perPage = any(),
@@ -88,7 +88,7 @@ internal class CommitServiceTest {
     private companion object {
         const val startTime = "2021-08-10T01:46:31Z"
         const val endTime = "2021-08-11T01:46:31Z"
-        val startTimeStamp = ZonedDateTime.parse(startTime)!!.toTimestamp()
-        val endTimeStamp = ZonedDateTime.parse(endTime)!!.toTimestamp()
+        val startTimeStamp = ZonedDateTime.parse(startTime)!!
+        val endTimeStamp = ZonedDateTime.parse(endTime)!!
     }
 }

--- a/backend/src/test/kotlin/metrik/project/domain/service/githubactions/PipelineCommitServiceTest.kt
+++ b/backend/src/test/kotlin/metrik/project/domain/service/githubactions/PipelineCommitServiceTest.kt
@@ -4,7 +4,6 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
-import metrik.infrastructure.utlils.toTimestamp
 import metrik.project.TestFixture.branch
 import metrik.project.TestFixture.commit
 import metrik.project.TestFixture.currentTimeStamp
@@ -46,8 +45,8 @@ class PipelineCommitServiceTest {
 
         every {
             commitService.getCommitsBetweenTimePeriod(
-                ZonedDateTime.parse("2021-04-23T13:41:01.779Z")!!.toTimestamp(),
-                ZonedDateTime.parse("2021-08-17T12:23:25Z")!!.toTimestamp(),
+                ZonedDateTime.parse("2021-04-23T13:41:01.779Z")!!,
+                ZonedDateTime.parse("2021-08-17T12:23:25Z")!!,
                 branch = branch,
                 pipeline = githubActionsPipeline
             )
@@ -75,8 +74,8 @@ class PipelineCommitServiceTest {
 
         every {
             commitService.getCommitsBetweenTimePeriod(
-                startTimeStamp = 0,
-                ZonedDateTime.parse("2021-08-17T12:23:25Z")!!.toTimestamp(),
+                startTimeStamp = null,
+                ZonedDateTime.parse("2021-08-17T12:23:25Z")!!,
                 branch = branch,
                 pipeline = githubActionsPipeline
             )
@@ -106,8 +105,8 @@ class PipelineCommitServiceTest {
 
         every {
             commitService.getCommitsBetweenTimePeriod(
-                0,
-                ZonedDateTime.parse("2021-08-17T12:23:25Z")!!.toTimestamp(),
+                null,
+                ZonedDateTime.parse("2021-08-17T12:23:25Z")!!,
                 branch = branch,
                 pipeline = githubActionsPipeline
             )
@@ -153,8 +152,8 @@ class PipelineCommitServiceTest {
 
         every {
             commitService.getCommitsBetweenTimePeriod(
-                ZonedDateTime.parse("2021-04-20T13:41:01.779Z")!!.toTimestamp(),
-                ZonedDateTime.parse("2021-08-17T12:23:25Z")!!.toTimestamp(),
+                ZonedDateTime.parse("2021-04-20T13:41:01.779Z")!!,
+                ZonedDateTime.parse("2021-08-17T12:23:25Z")!!,
                 branch = branch,
                 pipeline = githubActionsPipeline
             )
@@ -193,8 +192,8 @@ class PipelineCommitServiceTest {
 
         every {
             commitService.getCommitsBetweenTimePeriod(
-                startTimeStamp = 0,
-                endTimeStamp = ZonedDateTime.parse("2021-08-17T12:23:25Z")!!.toTimestamp(),
+                startTimeStamp = null,
+                endTimeStamp = ZonedDateTime.parse("2021-08-17T12:23:25Z")!!,
                 branch = branch,
                 pipeline = githubActionsPipeline
             )


### PR DESCRIPTION
According to this doc: https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28
the `since` and `until` should be ISO string instead of a long number.

So the change just updated the `CommitService`. After this change, it only accept the `ZonedDateTime` for the time range.



