### PR TITLE
feat: change `PUT /project/:id` interface to escape unnecessary quotes character

### DIFF
--- a/backend/src/main/kotlin/metrik/project/rest/ProjectController.kt
+++ b/backend/src/main/kotlin/metrik/project/rest/ProjectController.kt
@@ -2,6 +2,7 @@ package metrik.project.rest
 
 import metrik.project.rest.applicationservice.ProjectApplicationService
 import metrik.project.rest.vo.request.ProjectRequest
+import metrik.project.rest.vo.request.UpdateProjectRequest
 import metrik.project.rest.vo.response.ProjectDetailResponse
 import metrik.project.rest.vo.response.ProjectResponse
 import metrik.project.rest.vo.response.ProjectSummaryResponse
@@ -17,7 +18,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import javax.validation.Valid
-import javax.validation.constraints.NotBlank
 
 @RestController
 @RequestMapping("/api")
@@ -46,9 +46,9 @@ class ProjectController {
     @ResponseStatus(HttpStatus.OK)
     fun updateProjectName(
         @PathVariable projectId: String,
-        @RequestBody @Valid @NotBlank projectName: String
+        @RequestBody @Valid updateProjectRequest: UpdateProjectRequest
     ) {
-        projectApplicationService.updateProjectName(projectId, projectName)
+        projectApplicationService.updateProjectName(projectId, updateProjectRequest)
     }
 
     @DeleteMapping("/project/{projectId}")

--- a/backend/src/main/kotlin/metrik/project/rest/applicationservice/ProjectApplicationService.kt
+++ b/backend/src/main/kotlin/metrik/project/rest/applicationservice/ProjectApplicationService.kt
@@ -6,6 +6,7 @@ import metrik.project.domain.repository.PipelineRepository
 import metrik.project.domain.repository.ProjectRepository
 import metrik.project.exception.ProjectNameDuplicateException
 import metrik.project.rest.vo.request.ProjectRequest
+import metrik.project.rest.vo.request.UpdateProjectRequest
 import metrik.project.rest.vo.response.ProjectDetailResponse
 import metrik.project.rest.vo.response.ProjectResponse
 import metrik.project.rest.vo.response.ProjectSummaryResponse
@@ -43,8 +44,8 @@ class ProjectApplicationService {
         return ProjectSummaryResponse(savedProject)
     }
 
-    fun updateProjectName(projectId: String, projectName: String): ProjectResponse {
-        verifyProjectNameNotDuplicate(projectName)
+    fun updateProjectName(projectId: String, updateProjectRequest: UpdateProjectRequest): ProjectResponse {
+        val projectName = updateProjectRequest.projectName
         val project = projectRepository.findById(projectId)
         project.name = projectName
         return ProjectResponse(projectRepository.save(project))

--- a/backend/src/main/kotlin/metrik/project/rest/vo/request/Request.kt
+++ b/backend/src/main/kotlin/metrik/project/rest/vo/request/Request.kt
@@ -14,6 +14,11 @@ data class ProjectRequest(
     val pipeline: PipelineRequest
 )
 
+data class UpdateProjectRequest(
+    @field:NotBlank(message = "Project name cannot be empty")
+    val projectName: String
+)
+
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.PROPERTY,

--- a/backend/src/test/kotlin/metrik/project/rest/ProjectControllerTest.kt
+++ b/backend/src/test/kotlin/metrik/project/rest/ProjectControllerTest.kt
@@ -8,6 +8,7 @@ import metrik.project.TestFixture.buildJenkinsPipelineRequest
 import metrik.project.rest.applicationservice.ProjectApplicationService
 import metrik.project.rest.vo.request.BambooPipelineRequest
 import metrik.project.rest.vo.request.ProjectRequest
+import metrik.project.rest.vo.request.UpdateProjectRequest
 import metrik.project.rest.vo.response.PipelineResponse
 import metrik.project.rest.vo.response.ProjectDetailResponse
 import metrik.project.rest.vo.response.ProjectResponse
@@ -114,7 +115,8 @@ internal class ProjectControllerTest {
     @Test
     fun `should update project name `() {
         val projectNewName = "projectNewName"
-        every { projectApplicationService.updateProjectName(projectId, projectNewName) } returns ProjectResponse(
+        val updateProjectRequest = UpdateProjectRequest(projectNewName)
+        every { projectApplicationService.updateProjectName(projectId, updateProjectRequest) } returns ProjectResponse(
             projectId,
             projectNewName
         )
@@ -122,7 +124,7 @@ internal class ProjectControllerTest {
         mockMvc.perform(
             MockMvcRequestBuilders.put("/api/project/$projectId")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(projectNewName)
+                .content(ObjectMapper().writeValueAsString(updateProjectRequest))
         ).andExpect(status().isOk)
     }
 

--- a/backend/src/test/kotlin/metrik/project/rest/applicationservice/ProjectApplicationServiceTest.kt
+++ b/backend/src/test/kotlin/metrik/project/rest/applicationservice/ProjectApplicationServiceTest.kt
@@ -17,6 +17,7 @@ import metrik.project.domain.repository.PipelineRepository
 import metrik.project.domain.repository.ProjectRepository
 import metrik.project.exception.ProjectNameDuplicateException
 import metrik.project.rest.vo.request.ProjectRequest
+import metrik.project.rest.vo.request.UpdateProjectRequest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -97,7 +98,7 @@ internal class ProjectApplicationServiceTest {
         every { projectRepository.save(expectedProject) } returns expectedProject
 
         val newProjectName = "new project name"
-        val updatedProject = projectApplicationService.updateProjectName(projectId, newProjectName)
+        val updatedProject = projectApplicationService.updateProjectName(projectId, UpdateProjectRequest(newProjectName))
 
         assertEquals(updatedProject.name, newProjectName)
     }

--- a/frontend/src/clients/projectApis.ts
+++ b/frontend/src/clients/projectApis.ts
@@ -7,7 +7,9 @@ export const updateProjectNameUsingPut = createRequest<{
 }>(({ projectId, projectName }) => ({
 	url: `/api/project/${projectId}`,
 	method: "PUT",
-	data: projectName,
+	data: {
+		projectName
+	},
 	headers: { "Content-Type": "application/json" },
 }));
 


### PR DESCRIPTION
Fixes #149 

**Before**
- UI (notice there's extra quotes (`""`) between project name after reloading the page


https://user-images.githubusercontent.com/7030099/219297637-ffd14f4f-ecca-4836-9e4c-e4cac746bb46.mp4



- Backend
![backend-before-put](https://user-images.githubusercontent.com/7030099/219296049-a1475344-249f-4fe2-a318-d76049142f64.png)


**After**
- UI (notice there's no more extra quotes (`""`) between project name

https://user-images.githubusercontent.com/7030099/219297261-9aaf96b7-09c9-45c0-85cd-a890da1abf88.mp4



- Backend
![backend-after-put](https://user-images.githubusercontent.com/7030099/219296069-4c5a0d79-da80-4248-82e6-54381435ddd9.png)
