### PR TITLE
<Issue-155> | When there are more than 30 branches in a repo, it is f…

### DIFF
--- a/backend/src/main/kotlin/metrik/project/infrastructure/github/feign/GithubFeignClient.kt
+++ b/backend/src/main/kotlin/metrik/project/infrastructure/github/feign/GithubFeignClient.kt
@@ -55,6 +55,8 @@ interface GithubFeignClient {
         @RequestHeader("credential") credential: String,
         @PathVariable("owner") owner: String,
         @PathVariable("repo") repo: String,
+        @RequestParam("per_page", required = false) perPage: Int? = 100,
+        @RequestParam("page", required = false) pageIndex: Int? = 1
     ): List<BranchResponse>?
 }
 


### PR DESCRIPTION
This is a fix for the below issue
When there are more than 30 branches in a repo, it is fetching the latest 30 and filtering the runs on those branches. This is causing issues. Detailed issue is raised at https://github.com/thoughtworks/metrik/issues/155.